### PR TITLE
Extract a database view for streaks to enable simpler and more powerful querying

### DIFF
--- a/priv/repo/migrations/20170111012241_add_streaks_view.exs
+++ b/priv/repo/migrations/20170111012241_add_streaks_view.exs
@@ -1,0 +1,38 @@
+defmodule Habits.Repo.Migrations.AddStreaksView do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    CREATE VIEW streaks AS
+      WITH start_streak AS (
+        SELECT
+          check_ins.date,
+          check_ins.habit_id,
+          CASE WHEN check_ins.date - LAG(check_ins.date, 1) OVER (PARTITION BY check_ins.habit_id ORDER BY check_ins.date) > 1
+            THEN 1
+            ELSE 0
+          END streak_start
+        FROM check_ins
+        ),
+        streak_groups AS (
+          SELECT
+            date,
+            habit_id,
+            SUM(streak_start) over (PARTITION BY habit_id ORDER BY date) streak
+          FROM start_streak
+        )
+      SELECT
+        habit_id,
+        MIN(date) AS start,
+        MAX(date) AS end,
+        MAX(date) - MIN(date) + 1 AS length
+      FROM streak_groups
+      GROUP BY habit_id, streak
+    ;
+    """
+  end
+
+  def down do
+    execute "DROP VIEW streaks;"
+  end
+end

--- a/test/controllers/api/v1/habits_controller_test.exs
+++ b/test/controllers/api/v1/habits_controller_test.exs
@@ -42,7 +42,9 @@ defmodule Habits.API.V1.HabitControllerTest do
       assert json_response(conn, :ok) == %{
         "id" => habit.id,
         "name" => habit.name,
-        "totalCheckIns" => 1
+        "totalCheckIns" => 1,
+        "currentStreak" => 1,
+        "longestStreak" => 1
       }
     end
   end

--- a/test/models/habit_test.exs
+++ b/test/models/habit_test.exs
@@ -51,6 +51,19 @@ defmodule Habits.HabitTest do
     end
   end
 
+  describe ".get_longest_streak" do
+
+    test "returns the longest consecutive streak for a habit" do
+      habit = Factory.insert(:habit)
+      Factory.insert(:check_in, habit: habit, date: days_ago(7))
+      Factory.insert(:check_in, habit: habit, date: days_ago(6))
+      Factory.insert(:check_in, habit: habit, date: days_ago(5))
+      Factory.insert(:check_in, habit: habit, date: days_ago(3))
+
+      assert Habit.get_longest_streak(habit) == 3
+    end
+  end
+
   defp days_ago(days) do
     Habits.Date.today
     |> Habits.Date.shift_days(-days)

--- a/web/models/habit.ex
+++ b/web/models/habit.ex
@@ -39,6 +39,16 @@ defmodule Habits.Habit do
   end
 
   @doc """
+  Returns the longest streak of consecutive daily check-ins for a habit
+  """
+  def get_longest_streak(habit) do
+    habit
+    |> assoc(:streaks)
+    |> select([s], max(s.length))
+    |> Repo.one || 0
+  end
+
+  @doc """
   Gets a habit for a given account.
   """
   def get_by_account(%Account{} = account, habit_id) do

--- a/web/models/habit.ex
+++ b/web/models/habit.ex
@@ -29,28 +29,13 @@ defmodule Habits.Habit do
   @doc """
   The current streak is the number of consecutive daily check-ins
   for a habit up until yesterday, or today if you’ve checked in today.
-
-  Hat tip: stackoverflow.com/q/22142028/
   """
   def get_current_streak(habit) do
-    yesterday_string =
-      Habits.Date.yesterday
-      |> Date.to_iso8601
-
-    sql = """
-    SELECT
-      COALESCE(streaks.length, 0)
-    FROM habits
-    LEFT JOIN streaks
-      ON habits.id = streaks.habit_id
-      AND streaks.end >= '#{yesterday_string}'::date
-    WHERE habits.id = #{habit.id}
-    LIMIT 1
-    ;
-    """
-
-    {:ok, %{rows: [[streak]]}} = Ecto.Adapters.SQL.query(Repo, sql, [])
-    streak
+    habit
+    |> assoc(:streaks)
+    |> where([s], s.end >= ^Habits.Date.yesterday)
+    |> select([s], s.length)
+    |> Repo.one || 0
   end
 
   @doc """

--- a/web/models/streak.ex
+++ b/web/models/streak.ex
@@ -1,0 +1,16 @@
+defmodule Habits.Streak do
+  @moduledoc """
+  Data logic for streaks of consecutive daily check-ins related to habits.
+  """
+
+  use Habits.Web, :model
+  alias Habits.Habit
+
+  @primary_key false
+  schema "streaks" do
+    belongs_to :habit, Habit
+    field :start, :date
+    field :end, :date
+    field :length, :integer
+  end
+end

--- a/web/static/css/_variables.scss
+++ b/web/static/css/_variables.scss
@@ -9,7 +9,8 @@ $red: #D13F54;
 $error-color: $red;
 
 $text-color: #fff;
-$light-border-color: rgba(255,255,255,.25);
+$body-text-shadow: 0 1px 1px rgba(0, 0, 0, .1);
+$light-border-color: rgba(255, 255, 255, .25);
 
 $light-border: 1px solid $light-border-color;
 

--- a/web/static/css/app.scss
+++ b/web/static/css/app.scss
@@ -14,7 +14,7 @@ html {
 body {
   font-family: "Lato", sans-serif;
   color: $text-color;
-  text-shadow: 0 1px 1px rgba(0,0,0,.1);
+  text-shadow: $body-text-shadow;
 }
 
 label {
@@ -157,13 +157,6 @@ a {
 
   &-streak {
     margin-left: 1em
-  }
-
-  &-streakIcon {
-    display: inline-block;
-    fill: #fff;
-    width: 1em;
-    height: 1em;
   }
 }
 
@@ -323,4 +316,12 @@ a {
   margin: 5em auto;
   -webkit-animation: rotateplane 1.2s infinite ease-in-out;
   animation: rotateplane 1.2s infinite ease-in-out;
+}
+
+.StreakIcon {
+  display: inline-block;
+  fill: #fff;
+  filter: drop-shadow($body-text-shadow);
+  height: .75em;
+  width: .75em;
 }

--- a/web/static/js/components/Habit.js
+++ b/web/static/js/components/Habit.js
@@ -35,7 +35,7 @@ class Habit extends React.Component {
         <Link to={`/habits/${id}`} className="Habit-name">{name}</Link>
         {streak > 0 &&
           <span className="Habit-streak">
-            <svg className="Habit-streakIcon" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" width="14" height="28" viewBox="0 0 14 28">
+            <svg className="StreakIcon" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" width="14" height="28" viewBox="0 0 14 28">
               <path d="M13.828 8.844c0.172 0.187 0.219 0.453 0.109 0.688l-8.437 18.078c-0.125 0.234-0.375 0.391-0.656 0.391-0.063 0-0.141-0.016-0.219-0.031-0.344-0.109-0.547-0.438-0.469-0.766l3.078-12.625-6.344 1.578c-0.063 0.016-0.125 0.016-0.187 0.016-0.172 0-0.359-0.063-0.484-0.172-0.187-0.156-0.25-0.391-0.203-0.609l3.141-12.891c0.078-0.297 0.359-0.5 0.688-0.5h5.125c0.391 0 0.703 0.297 0.703 0.656 0 0.094-0.031 0.187-0.078 0.281l-2.672 7.234 6.188-1.531c0.063-0.016 0.125-0.031 0.187-0.031 0.203 0 0.391 0.094 0.531 0.234z"></path>
             </svg>
             {streak}

--- a/web/static/js/components/HabitPage.js
+++ b/web/static/js/components/HabitPage.js
@@ -26,7 +26,7 @@ class HabitPage extends React.Component {
 
   handleDelete(event) {
     event.preventDefault()
-    const confirmed = confirm(`Are you sure you want to delete “${this.state.data.name}” and all of its check-ins?`)
+    const confirmed = confirm(`Are you sure you want to delete “${data.name}” and all of its check-ins?`)
     if (confirmed) {
       Request.delete(this.habitPath()).then(function(json) {
         browserHistory.push('/habits')
@@ -35,15 +35,36 @@ class HabitPage extends React.Component {
   }
 
   render() {
+    const { data } = this.state
     return (
     <div>
-      {!this.state.data && <Loading /> }
-      {this.state.data &&
+      {!data && <Loading /> }
+      {data &&
         <div className="center">
-          <h2>{this.state.data.name}</h2>
+          <h2>{data.name}</h2>
+
+          <p className="Metric">
+            <span className="Metric-title">Current Streak</span>
+            <span className="Metric-number">
+              <svg className="StreakIcon" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" width="14" height="28" viewBox="0 0 14 28">
+                <path d="M13.828 8.844c0.172 0.187 0.219 0.453 0.109 0.688l-8.437 18.078c-0.125 0.234-0.375 0.391-0.656 0.391-0.063 0-0.141-0.016-0.219-0.031-0.344-0.109-0.547-0.438-0.469-0.766l3.078-12.625-6.344 1.578c-0.063 0.016-0.125 0.016-0.187 0.016-0.172 0-0.359-0.063-0.484-0.172-0.187-0.156-0.25-0.391-0.203-0.609l3.141-12.891c0.078-0.297 0.359-0.5 0.688-0.5h5.125c0.391 0 0.703 0.297 0.703 0.656 0 0.094-0.031 0.187-0.078 0.281l-2.672 7.234 6.188-1.531c0.063-0.016 0.125-0.031 0.187-0.031 0.203 0 0.391 0.094 0.531 0.234z"></path>
+              </svg>
+              {Number(data.currentStreak).toLocaleString()}
+            </span>
+          </p>
+
+          <p className="Metric">
+            <span className="Metric-title">Longest Streak</span>
+            <span className="Metric-number">
+              {Number(data.longestStreak).toLocaleString()}
+            </span>
+          </p>
+
           <p className="Metric">
             <span className="Metric-title">Total Check-Ins</span>
-            <span className="Metric-number">{Number(this.state.data.totalCheckIns).toLocaleString()}</span>
+            <span className="Metric-number">
+              {Number(data.totalCheckIns).toLocaleString()}
+            </span>
           </p>
         </div>
       }

--- a/web/views/api/v1/habit_view.ex
+++ b/web/views/api/v1/habit_view.ex
@@ -13,7 +13,9 @@ defmodule Habits.API.V1.HabitView do
     %{
       id: habit.id,
       name: habit.name,
-      totalCheckIns: Habit.check_in_count(habit)
+      totalCheckIns: Habit.check_in_count(habit),
+      currentStreak: Habit.get_current_streak(habit),
+      longestStreak: Habit.get_longest_streak(habit)
     }
   end
 


### PR DESCRIPTION
I ❤️ ❤️ ❤️ how you can build Ecto schemas on top of database views just like you can with tables. This let me push the data logic for streaks down into the database and allow a *much* simpler querying syntax (no raw SQL) in the Elixir code. A refactor of the streaks query also enabled richer querying, such as for the longest streak as well as the current one:

<img width="410" alt="screen shot 2017-01-12 at 5 59 21 am" src="https://cloud.githubusercontent.com/assets/664341/21887032/48efdb8a-d88c-11e6-872c-cf24a96308d1.png">
