### PR TITLE
Convert the Account "model" into an Accounts "context" following Phoenix 1.3 conventions

### DIFF
--- a/lib/habits/accounts/account.ex
+++ b/lib/habits/accounts/account.ex
@@ -1,9 +1,10 @@
-defmodule HabitsWeb.Account do
+defmodule Habits.Accounts.Account do
   @moduledoc """
   Data logic for the Account domain model, which represents a user of the app.
   """
 
-  use Habits.Web, :model
+  use Ecto.Schema
+  import Ecto.Changeset
 
   alias Habits.Repo
   alias HabitsWeb.{Habit, Session}

--- a/lib/habits/accounts/account.ex
+++ b/lib/habits/accounts/account.ex
@@ -1,12 +1,11 @@
 defmodule Habits.Accounts.Account do
   @moduledoc """
-  Data logic for the Account domain model, which represents a user of the app.
+  Data logic for the Account schema, which represents a user of the app.
   """
 
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Habits.Repo
   alias HabitsWeb.{Habit, Session}
 
   schema "accounts" do
@@ -30,28 +29,6 @@ defmodule Habits.Accounts.Account do
     |> validate_length(:password, min: 5)
     |> encrypt_password_if_possible
     |> unique_constraint(:email)
-  end
-
-  @doc """
-  Returns a list of CheckIns-counts by week, beginning with the first week for
-  which there was a CheckIn
-  """
-  def check_in_data(_account) do
-    query = """
-    SELECT
-      COUNT(check_ins.*)
-    FROM generate_series((
-      SELECT MIN(date_trunc('week', check_ins.date))
-      FROM check_ins
-    ), NOW(), '1 week'::interval) week
-    LEFT OUTER JOIN check_ins
-      ON date_trunc('week', check_ins.date) = week
-    GROUP BY week
-    ORDER BY week
-    ;
-    """
-    %Postgrex.Result{rows: rows} = Ecto.Adapters.SQL.query!(Repo, query, [])
-    Enum.map(rows, &List.first/1)
   end
 
   defp encrypt_password_if_possible(

--- a/lib/habits/accounts/accounts.ex
+++ b/lib/habits/accounts/accounts.ex
@@ -2,4 +2,14 @@ defmodule Habits.Accounts do
   @moduledoc """
   The Accounts context.
   """
+
+  alias Habits.{Repo, Accounts.Account}
+
+  def registration_permitted? do
+    if Repo.exists?(Account) do
+      {:error, "An account already exists. Please log in."}
+    else
+      :ok
+    end
+  end
 end

--- a/lib/habits/accounts/accounts.ex
+++ b/lib/habits/accounts/accounts.ex
@@ -6,9 +6,13 @@ defmodule Habits.Accounts do
   alias Habits.{Repo, Accounts.Account}
 
   def create_account(attrs \\ %{}) do
-    %Account{}
-    |> Account.changeset(attrs)
-    |> Repo.insert()
+    if Repo.exists?(Account) do
+      {:error, "An account already exists. Please log in."}
+    else
+      %Account{}
+      |> Account.changeset(attrs)
+      |> Repo.insert()
+    end
   end
 
   def get_account!(id), do: Repo.get!(Account, id)
@@ -41,13 +45,5 @@ defmodule Habits.Accounts do
     """
     %Postgrex.Result{rows: rows} = Ecto.Adapters.SQL.query!(Repo, query, [])
     Enum.map(rows, &List.first/1)
-  end
-
-  def registration_permitted? do
-    if Repo.exists?(Account) do
-      {:error, "An account already exists. Please log in."}
-    else
-      :ok
-    end
   end
 end

--- a/lib/habits/accounts/accounts.ex
+++ b/lib/habits/accounts/accounts.ex
@@ -5,6 +5,44 @@ defmodule Habits.Accounts do
 
   alias Habits.{Repo, Accounts.Account}
 
+  def create_account(attrs \\ %{}) do
+    %Account{}
+    |> Account.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def get_account!(id), do: Repo.get!(Account, id)
+
+  def get_by_email(email) when is_binary(email) do
+    Account
+    |> Repo.get_by(email: email)
+  end
+
+  @doc """
+  Returns a list of CheckIns-counts by week, beginning with the first week for
+  which there was a CheckIn.
+
+  We ignore the %Account() argument assuming there can be only one,
+  but we should probably still specify that.
+  """
+  def time_series_check_in_data(_account) do
+    query = """
+    SELECT
+      COUNT(check_ins.*)
+    FROM generate_series((
+      SELECT MIN(date_trunc('week', check_ins.date))
+      FROM check_ins
+    ), NOW(), '1 week'::interval) week
+    LEFT OUTER JOIN check_ins
+      ON date_trunc('week', check_ins.date) = week
+    GROUP BY week
+    ORDER BY week
+    ;
+    """
+    %Postgrex.Result{rows: rows} = Ecto.Adapters.SQL.query!(Repo, query, [])
+    Enum.map(rows, &List.first/1)
+  end
+
   def registration_permitted? do
     if Repo.exists?(Account) do
       {:error, "An account already exists. Please log in."}

--- a/lib/habits/accounts/accounts.ex
+++ b/lib/habits/accounts/accounts.ex
@@ -1,0 +1,5 @@
+defmodule Habits.Accounts do
+  @moduledoc """
+  The Accounts context.
+  """
+end

--- a/lib/habits/achievements/achievements.ex
+++ b/lib/habits/achievements/achievements.ex
@@ -3,7 +3,8 @@ defmodule Habits.Achievements do
   The Achievements context.
   """
 
-  alias HabitsWeb.{Account, Habit}
+  alias HabitsWeb.{Habit}
+  alias Habits.{Accounts.Account}
   alias Habits.Achievements.{CheckInCount, HabitCount, StreakLength}
 
   @doc """

--- a/lib/habits/achievements/check_in_count.ex
+++ b/lib/habits/achievements/check_in_count.ex
@@ -3,8 +3,8 @@ defmodule Habits.Achievements.CheckInCount do
 
   use Habits.Achievements.Achievement
 
-  alias Habits.Repo
-  alias HabitsWeb.{Account, Habit}
+  alias Habits.{Repo, Accounts.Account}
+  alias HabitsWeb.{Habit}
 
   defp value_for(%Account{} = account) do
     Repo.count(Ecto.assoc(account, [:habits, :check_ins]))

--- a/lib/habits/achievements/habit_count.ex
+++ b/lib/habits/achievements/habit_count.ex
@@ -3,8 +3,7 @@ defmodule Habits.Achievements.HabitCount do
 
   use Habits.Achievements.Achievement
 
-  alias Habits.Repo
-  alias HabitsWeb.Account
+  alias Habits.{Repo, Accounts.Account}
 
   defp value_for(%Account{} = account) do
     Repo.count(Ecto.assoc(account, :habits))

--- a/lib/habits_web/controllers/api/v1/account_controller.ex
+++ b/lib/habits_web/controllers/api/v1/account_controller.ex
@@ -16,9 +16,8 @@ defmodule HabitsWeb.API.V1.AccountController do
   Register a new account unless one exists.
   """
   def create(conn, %{"account" => account_params}) do
-    with :ok <- Accounts.registration_permitted?,
-      {:ok, account} <- Accounts.create_account(account_params),
-      {:ok, session} <- create_session(account)
+    with {:ok, account} <- Accounts.create_account(account_params),
+         {:ok, session} <- create_session(account)
     do
       conn
       |> put_status(:created)

--- a/lib/habits_web/controllers/api/v1/account_controller.ex
+++ b/lib/habits_web/controllers/api/v1/account_controller.ex
@@ -15,11 +15,9 @@ defmodule HabitsWeb.API.V1.AccountController do
   @doc """
   Register a new account unless one exists.
   """
-  # @TODO: this belongs in a context, but which?
-  # Accounts, Sessions, or something else? Registrations?
   def create(conn, %{"account" => account_params}) do
     with :ok <- Accounts.registration_permitted?,
-      {:ok, account} <- create_account(account_params),
+      {:ok, account} <- Accounts.create_account(account_params),
       {:ok, session} <- create_session(account)
     do
       conn
@@ -31,13 +29,6 @@ defmodule HabitsWeb.API.V1.AccountController do
         |> put_status(:forbidden)
         |> render("error.json", message: message)
     end
-  end
-
-  # @TODO: make Accounts.create_account
-  defp create_account(account_params) do
-    %Accounts.Account{}
-    |> Accounts.Account.changeset(account_params)
-    |> Repo.insert
   end
 
   # @TODO: make Sessions.create_session

--- a/lib/habits_web/controllers/api/v1/account_controller.ex
+++ b/lib/habits_web/controllers/api/v1/account_controller.ex
@@ -18,7 +18,7 @@ defmodule HabitsWeb.API.V1.AccountController do
   # @TODO: this belongs in a context, but which?
   # Accounts, Sessions, or something else? Registrations?
   def create(conn, %{"account" => account_params}) do
-    with :ok <- can_create_account?(),
+    with :ok <- Accounts.registration_permitted?,
       {:ok, account} <- create_account(account_params),
       {:ok, session} <- create_session(account)
     do
@@ -30,15 +30,6 @@ defmodule HabitsWeb.API.V1.AccountController do
         conn
         |> put_status(:forbidden)
         |> render("error.json", message: message)
-    end
-  end
-
-  # @TODO: make Accounts.registration_permitted?
-  defp can_create_account? do
-    if Repo.exists?(Accounts.Account) do
-      {:error, "An account already exists. Please log in."}
-    else
-      :ok
     end
   end
 

--- a/lib/habits_web/controllers/api/v1/account_controller.ex
+++ b/lib/habits_web/controllers/api/v1/account_controller.ex
@@ -1,8 +1,8 @@
 defmodule HabitsWeb.API.V1.AccountController do
   use Habits.Web, :controller
 
-  alias Habits.Repo
-  alias HabitsWeb.{Account, Session, API.V1.SessionView}
+  alias Habits.{Repo, Accounts}
+  alias HabitsWeb.{Session, API.V1.SessionView}
 
   @doc """
   Return information about the current user’s account
@@ -15,6 +15,8 @@ defmodule HabitsWeb.API.V1.AccountController do
   @doc """
   Register a new account unless one exists.
   """
+  # @TODO: this belongs in a context, but which?
+  # Accounts, Sessions, or something else? Registrations?
   def create(conn, %{"account" => account_params}) do
     with :ok <- can_create_account?(),
       {:ok, account} <- create_account(account_params),
@@ -31,21 +33,24 @@ defmodule HabitsWeb.API.V1.AccountController do
     end
   end
 
+  # @TODO: make Accounts.registration_permitted?
   defp can_create_account? do
-    if Repo.exists?(Account) do
+    if Repo.exists?(Accounts.Account) do
       {:error, "An account already exists. Please log in."}
     else
       :ok
     end
   end
 
+  # @TODO: make Accounts.create_account
   defp create_account(account_params) do
-    %Account{}
-    |> Account.changeset(account_params)
+    %Accounts.Account{}
+    |> Accounts.Account.changeset(account_params)
     |> Repo.insert
   end
 
-  defp create_session(%Account{id: account_id}) do
+  # @TODO: make Sessions.create_session
+  defp create_session(%Accounts.Account{id: account_id}) do
     %Session{}
     |> Session.changeset(%{account_id: account_id, location: "Initial registration"})
     |> Repo.insert

--- a/lib/habits_web/controllers/api/v1/session_controller.ex
+++ b/lib/habits_web/controllers/api/v1/session_controller.ex
@@ -3,7 +3,8 @@ defmodule HabitsWeb.API.V1.SessionController do
 
   import Comeonin.Bcrypt, only: [checkpw: 2, dummy_checkpw: 0]
 
-  alias HabitsWeb.{Account, Session}
+  alias Habits.Accounts.Account
+  alias HabitsWeb.Session
 
   def index(conn, %{}) do
     current_account = conn.assigns.current_account
@@ -17,6 +18,7 @@ defmodule HabitsWeb.API.V1.SessionController do
   end
 
   def create(conn, %{"account" => account_params}) do
+    # @TODO: make Accounts.get_by_email!
     account = Repo.get_by(Account, email: account_params["email"])
     cond do
       account && checkpw(account_params["password"], account.encrypted_password) ->

--- a/lib/habits_web/controllers/api/v1/session_controller.ex
+++ b/lib/habits_web/controllers/api/v1/session_controller.ex
@@ -3,7 +3,7 @@ defmodule HabitsWeb.API.V1.SessionController do
 
   import Comeonin.Bcrypt, only: [checkpw: 2, dummy_checkpw: 0]
 
-  alias Habits.Accounts.Account
+  alias Habits.Accounts
   alias HabitsWeb.Session
 
   def index(conn, %{}) do
@@ -18,8 +18,7 @@ defmodule HabitsWeb.API.V1.SessionController do
   end
 
   def create(conn, %{"account" => account_params}) do
-    # @TODO: make Accounts.get_by_email!
-    account = Repo.get_by(Account, email: account_params["email"])
+    account = Accounts.get_by_email(account_params["email"])
     cond do
       account && checkpw(account_params["password"], account.encrypted_password) ->
         session_changeset = Session.changeset(%Session{}, %{

--- a/lib/habits_web/models/habit.ex
+++ b/lib/habits_web/models/habit.ex
@@ -6,8 +6,8 @@ defmodule HabitsWeb.Habit do
 
   use Habits.Web, :model
 
-  alias Habits.Repo
-  alias HabitsWeb.{Account, CheckIn, Streak}
+  alias Habits.{Repo, Accounts.Account}
+  alias HabitsWeb.{CheckIn, Streak}
 
   schema "habits" do
     field :name, :string

--- a/lib/habits_web/models/session.ex
+++ b/lib/habits_web/models/session.ex
@@ -6,7 +6,7 @@ defmodule HabitsWeb.Session do
 
   use Habits.Web, :model
 
-  alias HabitsWeb.Account
+  alias Habits.Accounts.Account
 
   @timestamps_opts type: :utc_datetime, usec: false
   schema "sessions" do

--- a/lib/habits_web/plugs/token_authentication.ex
+++ b/lib/habits_web/plugs/token_authentication.ex
@@ -6,8 +6,8 @@ defmodule HabitsWeb.TokenAuthentication do
   """
 
   import Plug.Conn
-  alias Habits.Repo
-  alias HabitsWeb.{Account, Session}
+  alias Habits.{Repo, Accounts.Account}
+  alias HabitsWeb.{Session}
   import Ecto.Query, only: [from: 2]
 
   def init(options), do: options

--- a/lib/habits_web/plugs/token_authentication.ex
+++ b/lib/habits_web/plugs/token_authentication.ex
@@ -6,13 +6,13 @@ defmodule HabitsWeb.TokenAuthentication do
   """
 
   import Plug.Conn
-  alias Habits.{Repo, Accounts.Account}
+  alias Habits.{Repo, Accounts}
   alias HabitsWeb.{Session}
   import Ecto.Query, only: [from: 2]
 
   def init(options), do: options
 
-  def call(%Plug.Conn{assigns: %{current_account: %Account{}}} = conn, _opts) do
+  def call(%Plug.Conn{assigns: %{current_account: %Accounts.Account{}}} = conn, _opts) do
     conn # Allow manually setting current_account in tests
   end
   def call(conn, _opts) do
@@ -42,7 +42,7 @@ defmodule HabitsWeb.TokenAuthentication do
   end
 
   defp find_account_by_session(session) do
-    case Repo.get(Account, session.account_id) do
+    case Accounts.get_account!(session.account_id) do
       nil  -> :error
       account -> {:ok, account}
     end

--- a/lib/habits_web/views/api/v1/account_view.ex
+++ b/lib/habits_web/views/api/v1/account_view.ex
@@ -1,7 +1,7 @@
 defmodule HabitsWeb.API.V1.AccountView do
   use Habits.Web, :view
 
-  alias HabitsWeb.{Account}
+  alias Habits.{Accounts.Account}
 
   def render("show.json", %{account: account}) do
     %{

--- a/lib/habits_web/views/api/v1/account_view.ex
+++ b/lib/habits_web/views/api/v1/account_view.ex
@@ -1,12 +1,12 @@
 defmodule HabitsWeb.API.V1.AccountView do
   use Habits.Web, :view
 
-  alias Habits.{Accounts.Account}
+  alias Habits.{Accounts}
 
   def render("show.json", %{account: account}) do
     %{
       email: account.email,
-      checkInData: Account.check_in_data(account)
+      checkInData: Accounts.time_series_check_in_data(account)
     }
   end
 

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -141,6 +141,37 @@ CREATE TABLE schema_migrations (
 
 
 --
+-- Name: services; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE services (
+    id integer NOT NULL,
+    name character varying(255),
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE services_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: services_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE services_id_seq OWNED BY services.id;
+
+
+--
 -- Name: sessions; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -222,6 +253,13 @@ ALTER TABLE ONLY habits ALTER COLUMN id SET DEFAULT nextval('habits_id_seq'::reg
 
 
 --
+-- Name: services id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY services ALTER COLUMN id SET DEFAULT nextval('services_id_seq'::regclass);
+
+
+--
 -- Name: sessions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -258,6 +296,14 @@ ALTER TABLE ONLY habits
 
 ALTER TABLE ONLY schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: services services_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY services
+    ADD CONSTRAINT services_pkey PRIMARY KEY (id);
 
 
 --
@@ -338,5 +384,5 @@ ALTER TABLE ONLY sessions
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO "schema_migrations" (version) VALUES (20160607225931), (20160611154829), (20160611162028), (20161231231911), (20170107011711), (20170111012241);
+INSERT INTO "schema_migrations" (version) VALUES (20160607225931), (20160611154829), (20160611162028), (20161231231911), (20170107011711), (20170111012241), (20170730002621);
 

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -141,37 +141,6 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: services; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE services (
-    id integer NOT NULL,
-    name character varying(255),
-    inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE services_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: services_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE services_id_seq OWNED BY services.id;
-
-
---
 -- Name: sessions; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -253,13 +222,6 @@ ALTER TABLE ONLY habits ALTER COLUMN id SET DEFAULT nextval('habits_id_seq'::reg
 
 
 --
--- Name: services id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY services ALTER COLUMN id SET DEFAULT nextval('services_id_seq'::regclass);
-
-
---
 -- Name: sessions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -296,14 +258,6 @@ ALTER TABLE ONLY habits
 
 ALTER TABLE ONLY schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
-
-
---
--- Name: services services_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY services
-    ADD CONSTRAINT services_pkey PRIMARY KEY (id);
 
 
 --
@@ -384,5 +338,5 @@ ALTER TABLE ONLY sessions
 -- PostgreSQL database dump complete
 --
 
-INSERT INTO "schema_migrations" (version) VALUES (20160607225931), (20160611154829), (20160611162028), (20161231231911), (20170107011711), (20170111012241), (20170730002621);
+INSERT INTO "schema_migrations" (version) VALUES (20160607225931), (20160611154829), (20160611162028), (20161231231911), (20170107011711), (20170111012241);
 

--- a/test/controllers/api/v1/account_controller_test.exs
+++ b/test/controllers/api/v1/account_controller_test.exs
@@ -1,7 +1,8 @@
 defmodule Habits.API.V1.AccountControllerTest do
   use HabitsWeb.ConnCase
 
-  alias HabitsWeb.{Account, Session}
+  alias Habits.Accounts.Account
+  alias HabitsWeb.{Session}
 
   describe ".show" do
 

--- a/test/controllers/api/v1/session_controller_test.exs
+++ b/test/controllers/api/v1/session_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule Habits.API.V1.SessionControllerTest do
   use HabitsWeb.ConnCase
 
-  alias Habits.{Accounts.Account}
+  alias Habits.{Accounts}
   alias HabitsWeb.{Session}
   @valid_attrs %{email: "foo@bar.com", password: "p4ssw0rd"}
 
@@ -34,8 +34,7 @@ defmodule Habits.API.V1.SessionControllerTest do
   describe ".create" do
 
     setup %{conn: conn} do
-      changeset = Account.changeset(%Account{}, @valid_attrs)
-      Repo.insert(changeset)
+      Accounts.create_account(@valid_attrs)
       {:ok, conn: put_req_header(conn, "accept", "application/json")}
     end
 

--- a/test/controllers/api/v1/session_controller_test.exs
+++ b/test/controllers/api/v1/session_controller_test.exs
@@ -1,7 +1,8 @@
 defmodule Habits.API.V1.SessionControllerTest do
   use HabitsWeb.ConnCase
 
-  alias HabitsWeb.{Session, Account}
+  alias Habits.{Accounts.Account}
+  alias HabitsWeb.{Session}
   @valid_attrs %{email: "foo@bar.com", password: "p4ssw0rd"}
 
   describe ".index" do

--- a/test/models/account_test.exs
+++ b/test/models/account_test.exs
@@ -1,7 +1,7 @@
 defmodule Habits.AccountTest do
   use Habits.DataCase
 
-  alias HabitsWeb.Account
+  alias Habits.{Accounts.Account}
 
   @valid_attrs %{
     email: "foo@bar.baz",

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -2,7 +2,7 @@ defmodule Habits.Factory do
   use ExMachina.Ecto, repo: Habits.Repo
 
   def account_factory do
-    %HabitsWeb.Account{
+    %Habits.Accounts.Account{
       email: sequence(:email, &"email-#{&1}@example.com"),
       encrypted_password: "password"
     }


### PR DESCRIPTION
I'm really liking contexts. It's a perfect way to get complex logic out of controllers and into a central place where it's easier to refactor. I love how clean it makes my controllers, and I love how it encourages me to name things, like `Accounts.create_account` instead of a repeated pipe chain of `Repo` and schema functions.