### PR TITLE
Get acceptance specs passing locally once again

### DIFF
--- a/test/acceptance/account_management_test.exs
+++ b/test/acceptance/account_management_test.exs
@@ -30,9 +30,9 @@ defmodule Habits.AccountManagementTest do
     |> assert_has(css(".ActionList-item", text: "Earth (Current)"))
     |> find(css(".ActionList-item", text: "Area 51"))
     |> click(link("×"))
-    |> refute_has(css(".ActionList-item", text: "Area 51"))
 
     session
+    |> refute_has(css(".ActionList-item", text: "Area 51"))
     |> click(link("Log Out"))
     |> assert_has(css(".lead"))
   end


### PR DESCRIPTION
This spec is failing locally because at the point in which we call `refute_has`, we’ve scoped the `css` selector to within `.ActionList-item` thanks to `find` on line 31. By re-scoping `refute_has` to the original `session`, we should be looking for (and expecting not to find) `.ActionList-item` on the entire page, not within the removed `.ActionList-item` element.

Perhaps related to #25, although the CI build appears to be failing for different, low-level reasons:

<img width="1119" alt="screen shot 2018-11-04 at 6 59 53 am" src="https://user-images.githubusercontent.com/664341/47964179-c3d77080-e003-11e8-81db-1dc4c6a359cc.png">
